### PR TITLE
Replace insecure way of adding gem to Gemfile with secure one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ with fragments found in the AJAX response.
 Add `fragments.js` gem to your application's Gemfile:
 
 ```ruby
-gem "fragments.js", github: "fs/fragments.js"
+gem "fragments.js", git: "https://github.com/fs/fragments.js.git"
 ```
 
 Require it in `application.js`:


### PR DESCRIPTION
bundler-audit will warn us that an "Insecure Source URI" has been found, and that's because a gem is installed from an insecure source git://github.com which could be subjected to MITM attacks.

The solution is to either install the gem from https:// or use a released gem.
